### PR TITLE
Fixing origin parameter in cloudfront module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ module "s3_website_bucket" {
 
 module "cloud_distribution" {
   source                     = "./modules/cloudfront"
-  s3_bucket_website_endpoint = module.s3_website_bucket.website_endpoint
-  bucket_name                = module.s3_website_bucket.website_bucket_name
+  s3_bucket_website_regional_domain_name = module.s3_website_bucket.website_bucket_regional_domain_name
+  bucket_name                = module.s3_website_bucket.website_bucket_domain_name
   depends_on                 = [module.s3_website_bucket] 
 }

--- a/modules/cloudfront/main.tf
+++ b/modules/cloudfront/main.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudfront_distribution" "cv_distribution" {
   origin {
-    domain_name = var.s3_bucket_website_endpoint
+    domain_name = var.s3_bucket_website_regional_domain_name
     origin_id   = "S3-${var.bucket_name}"
   }
 

--- a/modules/cloudfront/variables.tf
+++ b/modules/cloudfront/variables.tf
@@ -1,4 +1,4 @@
-variable "s3_bucket_website_endpoint" {
+variable "s3_bucket_website_regional_domain_name" {
   description = "The website endpoint of the S3 bucket"
   type        = string
 }

--- a/modules/s3_website_bucket/outputs.tf
+++ b/modules/s3_website_bucket/outputs.tf
@@ -12,3 +12,13 @@ output "website_bucket_arn" {
   description = "ARN of the bucket"
   value       = aws_s3_bucket.website_bucket.arn
 }
+
+output "website_bucket_domain_name" {
+  description = "Bucket domain name"
+  value       = aws_s3_bucket.website_bucket.bucket_domain_name
+}
+
+output "website_bucket_regional_domain_name" {
+  description = "Bucket domain name"
+  value       = aws_s3_bucket.website_bucket.bucket_regional_domain_name
+}


### PR DESCRIPTION
bucket regional name is to be used by cloudfront origin.domain_name parameter