### PR TITLE
fixing lambda url output

### DIFF
--- a/modules/lambda/outputs.tf
+++ b/modules/lambda/outputs.tf
@@ -5,5 +5,5 @@ output "lambda_visitors_counter_updater_arn" {
 
 output "lambda_visitors_counter_updater_url" {
   description = "The url of the lambda function - visitors counter updater"
-  value       = aws_lambda_function_url.visitors_counter_updater_url
+  value       = aws_lambda_function_url.visitors_counter_updater_url.function_url
 }


### PR DESCRIPTION
adding the function_url variable in the output to get the function string.